### PR TITLE
Giving option for deterministic Youtube search behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ export HUBOT_YOUTUBE_API_KEY=<your token>
 
 _[Learn more](https://developers.google.com/console/help/new/?hl=en_US#generatingdevkeys) about how to generate Google credentials._
 
+### Optionally set flag for deterministic searching
+
+If you want hubot to only return the most relevant result rather than randomly one of the top 15 results, set the environment variable `HUBOT_YOUTUBE_DETERMINISTIC_RESULTS`.
+
+```
+export HUBOT_YOUTUBE_DETERMINISTIC_RESULTS=true
+```
+
 ## Sample Interaction
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Then add **hubot-youtube** to your `external-scripts.json`:
 ]
 ```
 
+## Configuration
+
+Setting the environment variable `HUBOT_YOUTUBE_DETERMINISTIC_RESULTS` to `true`
+will force `hubot-youtube` to only request one result from the YouTube API. This
+means, for a given set of results available on YouTube, `hubot-youtube` will
+only get the most relevant result. Other values for this variable will result in
+`hubot-youtube` selecting a result at random from the most relevant results
+returned by the YouTube API.
+
 ## Sample Interaction
 
 ```

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -9,7 +9,7 @@ module.exports = (robot) ->
     robot.http("http://gdata.youtube.com/feeds/api/videos")
       .query({
         orderBy: "relevance"
-        'max-results': 15
+        'max-results': 1
         alt: 'json'
         q: query
       })

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -6,10 +6,16 @@
 module.exports = (robot) ->
   robot.respond /(youtube|yt)( me)? (.*)/i, (msg) ->
     query = msg.match[3]
+    maxResults = if process.env.HUBOT_YOUTUBE_DETERMINISTIC_RESULTS == 'true'
+      1
+    else
+      15
+    else
+      15
     robot.http("http://gdata.youtube.com/feeds/api/videos")
       .query({
         orderBy: "relevance"
-        'max-results': 1
+        'max-results': maxResults
         alt: 'json'
         q: query
       })

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -3,6 +3,8 @@
 #
 # Configuration:
 #   HUBOT_YOUTUBE_API_KEY - Obtained from https://console.developers.google.com
+#   HUBOT_YOUTUBE_DETERMINISTIC_RESULTS - Optional boolean flag to only fetch
+#     the top result from the YouTube search
 #
 # Commands:
 #   hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -6,12 +6,7 @@
 module.exports = (robot) ->
   robot.respond /(youtube|yt)( me)? (.*)/i, (msg) ->
     query = msg.match[3]
-    maxResults = if process.env.HUBOT_YOUTUBE_DETERMINISTIC_RESULTS == 'true'
-      1
-    else
-      15
-    else
-      15
+    maxResults = if process.env.HUBOT_YOUTUBE_DETERMINISTIC_RESULTS == 'true' then 1 else 15
     robot.http("http://gdata.youtube.com/feeds/api/videos")
       .query({
         orderBy: "relevance"


### PR DESCRIPTION
@dualmoon suggested in their own fork of hubot-youtube to only search for the most relevant result. This would change the behavior to be fully deterministic and only return the top YouTube search result rather than a random result from the top 15.