### PR TITLE
Switch to API Token-based search

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create a "Public" token rather than the OAuth credentials for this particular im
 
 ![Get Public Token](https://cloud.githubusercontent.com/assets/80459/7600553/f2fa44c2-f8d1-11e4-8edf-009c0e3f04f1.png)
 
-Copy your token to the environment `YOUTUBE_API_KEY` variable.
+Copy your token to the `YOUTUBE_API_KEY` environment variable.
 
 ```
 export YOUTUBE_API_KEY=<your token>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Then add **hubot-youtube** to your `external-scripts.json`:
 ]
 ```
 
+Obtain a [Google Developer Console](https://console.developers.google.com) token. You will want the "Public" token rather than the OAuth credentials for this particular implementation. [Learn more](https://developers.google.com/console/help/new/?hl=en_US#generatingdevkeys)
+
+```
+export YOUTUBE_API_KEY=<your token>
+```
+
 ## Sample Interaction
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Create a "Public" token rather than the OAuth credentials for this particular im
 
 ![Get Public Token](https://cloud.githubusercontent.com/assets/80459/7600553/f2fa44c2-f8d1-11e4-8edf-009c0e3f04f1.png)
 
-Copy your token to the `YOUTUBE_API_KEY` environment variable.
+Copy your token to the `HUBOT_YOUTUBE_API_KEY` environment variable.
 
 ```
-export YOUTUBE_API_KEY=<your token>
+export HUBOT_YOUTUBE_API_KEY=<your token>
 ```
 
 _[Learn more](https://developers.google.com/console/help/new/?hl=en_US#generatingdevkeys) about how to generate Google credentials._

--- a/README.md
+++ b/README.md
@@ -18,11 +18,23 @@ Then add **hubot-youtube** to your `external-scripts.json`:
 ]
 ```
 
-Obtain a [Google Developer Console](https://console.developers.google.com) token. You will want the "Public" token rather than the OAuth credentials for this particular implementation. [Learn more](https://developers.google.com/console/help/new/?hl=en_US#generatingdevkeys)
+### Obtain a [Google Developer Console](https://console.developers.google.com) token
+
+Enable the "YouTube Data API v3" permission from the API menu.
+
+![Enable v3](https://cloud.githubusercontent.com/assets/80459/7863722/8161df38-0523-11e5-931a-5c2bf6d8105b.png)
+
+Create a "Public" token rather than the OAuth credentials for this particular implementation. 
+
+![Get Public Token](https://cloud.githubusercontent.com/assets/80459/7600553/f2fa44c2-f8d1-11e4-8edf-009c0e3f04f1.png)
+
+Copy your token to the environment `YOUTUBE_API_KEY` variable.
 
 ```
 export YOUTUBE_API_KEY=<your token>
 ```
+
+_[Learn more](https://developers.google.com/console/help/new/?hl=en_US#generatingdevkeys) about how to generate Google credentials._
 
 ## Sample Interaction
 

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -15,6 +15,7 @@ module.exports = (robot) ->
       .query({
         order: 'relevance'
         part: 'snippet'
+        type: 'video'
         maxResults: 15
         q: query
         key: process.env.YOUTUBE_API_KEY

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -2,14 +2,14 @@
 #   YouTube video search
 #
 # Configuration:
-#   YOUTUBE_API_KEY - Obtained from https://console.developers.google.com
+#   HUBOT_YOUTUBE_API_KEY - Obtained from https://console.developers.google.com
 #
 # Commands:
 #   hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.
 module.exports = (robot) ->
   robot.respond /(?:youtube|yt)(?: me)? (.*)/i, (msg) ->
-    unless process.env.YOUTUBE_API_KEY
-      return msg.send "You must configure the YOUTUBE_API_KEY environment variable"
+    unless process.env.HUBOT_YOUTUBE_API_KEY
+      return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"
     query = msg.match[1]
     robot.http("https://www.googleapis.com/youtube/v3/search")
       .query({
@@ -18,7 +18,7 @@ module.exports = (robot) ->
         type: 'video'
         maxResults: 15
         q: query
-        key: process.env.YOUTUBE_API_KEY
+        key: process.env.HUBOT_YOUTUBE_API_KEY
       })
       .get() (err, res, body) ->
         videos = JSON.parse(body)

--- a/test/youtube-test.coffee
+++ b/test/youtube-test.coffee
@@ -13,7 +13,4 @@ describe 'youtube', ->
     require('../src/youtube')(@robot)
 
   it 'registers a respond listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/hello/)
-
-  it 'registers a hear listener', ->
-    expect(@robot.hear).to.have.been.calledWith(/orly/)
+    expect(@robot.respond).to.have.been.calledWith(/(?:youtube|yt)(?: me)? (.*)/i)


### PR DESCRIPTION
Fixes #3

Prior to this PR, the YouTube Hubot package would return a `devicesupport` link indicating that the search functionality was broken because it was using an outdated API. This moves the search to V3 of the YouTube API and restores functionality. It will require the addition of `YOUTUBE_API_KEY` environment variable.

Also updated the test spec so it can be Travis-ized.