### PR TITLE
Fix sinon and chai dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,19 @@
     "hubot": "2.x"
   },
   "devDependencies": {
+    "chai": "^2.1.1",
+    "coffee-script": "1.6.3",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.12.7",
+    "grunt-release": "~0.11.0",
     "hubot": "2.x",
-    "mocha": "*",
-    "chai": "*",
-    "sinon-chai": "*",
-    "sinon": "*",
-    "grunt-mocha-test": "~0.7.0",
-    "grunt-release": "~0.6.0",
-    "matchdep": "~0.1.2",
-    "grunt-contrib-watch": "~0.5.3"
+    "matchdep": "~0.3.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.13.0",
+    "sinon-chai": "^2.7.0"
+
   },
   "main": "index.coffee",
   "scripts": {


### PR DESCRIPTION
Fixes:

```
$ npm install
npm ERR! Darwin 14.3.0
npm ERR! argv "/opt/boxen/nodenv/versions/v0.12.4/bin/node" "/opt/boxen/nodenv/versions/v0.12.4/bin/npm" "install"
npm ERR! node v0.12.4
npm ERR! npm  v2.10.1
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package chai does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer sinon-chai@2.7.0 wants chai@>=1.9.2 <3

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/technicalpickles/src/hubot-youtube/npm-debug.log
```