### PR TITLE
Cleanup package version mess I made

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-youtube",
   "description": "A hubot script for searching YouTube",
-  "version": "0.1.4",
+  "version": "1.0.1",
   "author": "Josh Nichols <technicalpickles@github.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, youtube",


### PR DESCRIPTION
This is to get the version mess I made cleaned up. I attempted to publish from a fork that wasn't caught up with master, which reset what was in the NPM database. This publishes a version that lines up with the previous v1.0.0 bump. :panda_face: