### PR TITLE
Improve error logging/handling

### DIFF
--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -14,9 +14,8 @@ module.exports = (robot) ->
       robot.logger.error 'HUBOT_YOUTUBE_API_KEY is not set.'
       return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"
     query = msg.match[1]
-    robot.logger.debug query
     maxResults = if process.env.HUBOT_YOUTUBE_DETERMINISTIC_RESULTS == 'true' then 1 else 15
-    robot.logger.debug maxResults
+    robot.logger.debug "Query: #{query}\n Max Results: #{maxResults}"
     robot.http("https://www.googleapis.com/youtube/v3/search")
       .query({
         order: 'relevance'
@@ -30,16 +29,19 @@ module.exports = (robot) ->
         robot.logger.debug body
         if err
           robot.logger.error err
-          return msg.send err
+          return robot.emit 'error', err, msg
         try
-          videos = JSON.parse(body)
+          if res.statusCode is 200
+            videos = JSON.parse(body)
+            robot.logger.debug "Videos: #{JSON.stringify(videos)}"
+          else
+            return robot.emit 'error', "#{res.statusCode}: #{body}", msg
         catch error
           robot.logger.error error
           return msg.send "Error! #{body}"
         if videos.error
           robot.logger.error videos.error
           return msg.send "Error! #{JSON.stringify(videos.error)}"
-        robot.logger.debug videos
         videos = videos.items
         unless videos? && videos.length > 0
           return msg.send "No video results for \"#{query}\""

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -11,9 +11,12 @@
 module.exports = (robot) ->
   robot.respond /(?:youtube|yt)(?: me)? (.*)/i, (msg) ->
     unless process.env.HUBOT_YOUTUBE_API_KEY
+      robot.logger.error 'HUBOT_YOUTUBE_API_KEY is not set.'
       return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"
     query = msg.match[1]
+    robot.logger.debug query
     maxResults = if process.env.HUBOT_YOUTUBE_DETERMINISTIC_RESULTS == 'true' then 1 else 15
+    robot.logger.debug maxResults
     robot.http("https://www.googleapis.com/youtube/v3/search")
       .query({
         order: 'relevance'
@@ -24,11 +27,21 @@ module.exports = (robot) ->
         key: process.env.HUBOT_YOUTUBE_API_KEY
       })
       .get() (err, res, body) ->
-        videos = JSON.parse(body)
+        robot.logger.debug body
+        if err
+          robot.logger.error err
+          return msg.send err
+        try
+          videos = JSON.parse(body)
+        catch error
+          robot.logger.error error
+          return msg.send "Error! #{body}"
+        if videos.error
+          robot.logger.error videos.error
+          return msg.send "Error! #{JSON.stringify(videos.error)}"
+        robot.logger.debug videos
         videos = videos.items
-
         unless videos? && videos.length > 0
           return msg.send "No video results for \"#{query}\""
-
-        video  = msg.random videos
+        video = msg.random videos
         msg.send "https://www.youtube.com/watch?v=#{video.id.videoId}"


### PR DESCRIPTION
There are a handful of things that can go awry with setting up this Hubot Script Package. Unfortunately, not all of them are terribly user friendly to report on. This PR logs the errors through the normal `robot.logger.*` methods and handles some more common cases where an invalid API Key is used, the key does not have API permissions, or some other issue comes up.

Fixes #8

/cc @jamespullar @edbury