### PR TITLE
 Add support for robot.hear

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ If you want hubot to only return the most relevant result rather than randomly o
 ```
 export HUBOT_YOUTUBE_DETERMINISTIC_RESULTS=true
 ```
+### Optionally set flag for listening on public channel
 
+If you want hubot to listen every messages (without mentioning him) on public channel
+
+```
+export HUBOT_YOUTUBE_HEAR=true
+```
 ## Sample Interaction
 
 ```

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -16,7 +16,6 @@ module.exports = (robot) ->
     trigger = /^(?:youtube|yt)(?: me)? (.*)/i  
 
   robot[resType] trigger, (msg) ->
-    console.log msg
     unless process.env.HUBOT_YOUTUBE_API_KEY
       robot.logger.error 'HUBOT_YOUTUBE_API_KEY is not set.'
       return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -10,10 +10,13 @@
 #   hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.
 module.exports = (robot) ->
   resType = "respond"
+  trigger = /(?:youtube|yt)(?: me)? (.*)/i
   if process.env.HUBOT_YOUTUBE_HEAR == 'true'
     resType = "hear"
-  
-  robot[resType] /(?:youtube|yt)(?: me)? (.*)/i, (msg) ->
+    trigger = /^(?:youtube|yt)(?: me)? (.*)/i  
+
+  robot[resType] trigger, (msg) ->
+    console.log msg
     unless process.env.HUBOT_YOUTUBE_API_KEY
       robot.logger.error 'HUBOT_YOUTUBE_API_KEY is not set.'
       return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"

--- a/src/youtube.coffee
+++ b/src/youtube.coffee
@@ -5,11 +5,15 @@
 #   HUBOT_YOUTUBE_API_KEY - Obtained from https://console.developers.google.com
 #   HUBOT_YOUTUBE_DETERMINISTIC_RESULTS - Optional boolean flag to only fetch
 #     the top result from the YouTube search
-#
+#   HUBOT_YOUTUBE_HEAR - Optional boolean flag to globally hear from channels
 # Commands:
 #   hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.
 module.exports = (robot) ->
-  robot.respond /(?:youtube|yt)(?: me)? (.*)/i, (msg) ->
+  resType = "respond"
+  if process.env.HUBOT_YOUTUBE_HEAR == 'true'
+    resType = "hear"
+  
+  robot[resType] /(?:youtube|yt)(?: me)? (.*)/i, (msg) ->
     unless process.env.HUBOT_YOUTUBE_API_KEY
       robot.logger.error 'HUBOT_YOUTUBE_API_KEY is not set.'
       return msg.send "You must configure the HUBOT_YOUTUBE_API_KEY environment variable"


### PR DESCRIPTION
Hi,

I've added the choice between "hear" and "respond".

If the env variable `HUBOT_YOUTUBE_HEAR` is set to true, hubot will respond to every messages *starting* with `yt` or `youtube`.

This simplify the usage of this script in public room.
Instead of typing `hubot yt some video`, you only have to `yt some video`

If `HUBOT_YOUTUBE_HEAR` is not set, it will continue to work as of now.
